### PR TITLE
Update JV formula to version v0.1.10

### DIFF
--- a/jv.rb
+++ b/jv.rb
@@ -1,8 +1,8 @@
 class Jv < Formula
     desc "JV IP Tool"
     homepage "https://github.com/vndr/jv"
-    url "https://github.com/vndr/jv/releases/download/v0.1.9/jv_Darwin_x86_64.tar.gz"
-    sha256 "d64dfcc517ad5c1464928975271e7af8440badf7f946f132f4ad2a07c1ae799d"
+    url "https://github.com/vndr/jv/releases/download/v0.1.10/jv_Darwin_x86_64.tar.gz"
+    sha256 "fd2dbab7f54d14b4a456aed93f95b0463486284bbd4eb49fd5a4904f74801185"
     version "v0.1.9"
   
     def install
@@ -21,19 +21,19 @@ class Jv < Formula
     
     if OS.mac?
       if Hardware::CPU.intel?
-        url "https://github.com/vndr/jv/releases/download/v0.1.9/jv_Darwin_x86_64.tar.gz"
-        sha256 "d64dfcc517ad5c1464928975271e7af8440badf7f946f132f4ad2a07c1ae799d"
+        url "https://github.com/vndr/jv/releases/download/v0.1.10/jv_Darwin_x86_64.tar.gz"
+        sha256 "fd2dbab7f54d14b4a456aed93f95b0463486284bbd4eb49fd5a4904f74801185"
       elsif Hardware::CPU.arm?
-        url "https://github.com/vndr/jv/releases/download/v0.1.9/jv_Darwin_arm64.tar.gz"
-        sha256 "d64dfcc517ad5c1464928975271e7af8440badf7f946f132f4ad2a07c1ae799d"
+        url "https://github.com/vndr/jv/releases/download/v0.1.10/jv_Darwin_arm64.tar.gz"
+        sha256 "fd2dbab7f54d14b4a456aed93f95b0463486284bbd4eb49fd5a4904f74801185"
       end
     elsif OS.linux?
       if Hardware::CPU.intel?
-        url "https://github.com/vndr/jv/releases/download/v0.1.9/jv_Linux_x86_64.tar.gz"
-        sha256 "d64dfcc517ad5c1464928975271e7af8440badf7f946f132f4ad2a07c1ae799d"
+        url "https://github.com/vndr/jv/releases/download/v0.1.10/jv_Linux_x86_64.tar.gz"
+        sha256 "fd2dbab7f54d14b4a456aed93f95b0463486284bbd4eb49fd5a4904f74801185"
       elsif Hardware::CPU.arm?
-        url "https://github.com/vndr/jv/releases/download/v0.1.9/jv_Linux_arm64.tar.gz"
-        sha256 "d64dfcc517ad5c1464928975271e7af8440badf7f946f132f4ad2a07c1ae799d"
+        url "https://github.com/vndr/jv/releases/download/v0.1.10/jv_Linux_arm64.tar.gz"
+        sha256 "fd2dbab7f54d14b4a456aed93f95b0463486284bbd4eb49fd5a4904f74801185"
       end
     end
   


### PR DESCRIPTION
This PR updates the JV formula to version v0.1.10 with the correct download URLs and SHA256 checksums.