### PR TITLE
Update JV formula to version v0.1.12

### DIFF
--- a/jv.rb
+++ b/jv.rb
@@ -1,9 +1,9 @@
 class Jv < Formula
     desc "JV IP Tool"
     homepage "https://github.com/vndr/jv"
-    url "https://github.com/vndr/jv/releases/download/v0.1.9/jv_Darwin_x86_64.tar.gz"
-    sha256 "d64dfcc517ad5c1464928975271e7af8440badf7f946f132f4ad2a07c1ae799d"
-    version "v0.1.9"
+    url "https://github.com/vndr/jv/releases/download/v0.1.12/jv_Darwin_x86_64.tar.gz"
+    sha256 "c908a71214f3e9b51a6c0d618e8e670e9a9b94081e426d25bab735d6c5a2d9f5"
+    version "v0.1.12"
   
     def install
       bin.install "jv"
@@ -21,19 +21,19 @@ class Jv < Formula
     
     if OS.mac?
       if Hardware::CPU.intel?
-        url "https://github.com/vndr/jv/releases/download/v0.1.9/jv_Darwin_x86_64.tar.gz"
-        sha256 "d64dfcc517ad5c1464928975271e7af8440badf7f946f132f4ad2a07c1ae799d"
+        url "https://github.com/vndr/jv/releases/download/v0.1.12/jv_Darwin_x86_64.tar.gz"
+        sha256 "c908a71214f3e9b51a6c0d618e8e670e9a9b94081e426d25bab735d6c5a2d9f5"
       elsif Hardware::CPU.arm?
-        url "https://github.com/vndr/jv/releases/download/v0.1.9/jv_Darwin_arm64.tar.gz"
-        sha256 "d64dfcc517ad5c1464928975271e7af8440badf7f946f132f4ad2a07c1ae799d"
+        url "https://github.com/vndr/jv/releases/download/v0.1.12/jv_Darwin_arm64.tar.gz"
+        sha256 "c908a71214f3e9b51a6c0d618e8e670e9a9b94081e426d25bab735d6c5a2d9f5"
       end
     elsif OS.linux?
       if Hardware::CPU.intel?
-        url "https://github.com/vndr/jv/releases/download/v0.1.9/jv_Linux_x86_64.tar.gz"
-        sha256 "d64dfcc517ad5c1464928975271e7af8440badf7f946f132f4ad2a07c1ae799d"
+        url "https://github.com/vndr/jv/releases/download/v0.1.12/jv_Linux_x86_64.tar.gz"
+        sha256 "c908a71214f3e9b51a6c0d618e8e670e9a9b94081e426d25bab735d6c5a2d9f5"
       elsif Hardware::CPU.arm?
-        url "https://github.com/vndr/jv/releases/download/v0.1.9/jv_Linux_arm64.tar.gz"
-        sha256 "d64dfcc517ad5c1464928975271e7af8440badf7f946f132f4ad2a07c1ae799d"
+        url "https://github.com/vndr/jv/releases/download/v0.1.12/jv_Linux_arm64.tar.gz"
+        sha256 "c908a71214f3e9b51a6c0d618e8e670e9a9b94081e426d25bab735d6c5a2d9f5"
       end
     end
   


### PR DESCRIPTION
This PR updates the JV formula to version v0.1.12 with the correct download URLs and SHA256 checksums.